### PR TITLE
chore: lock files maintenance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "@google-cloud/prediction",
+  "version": "0.8.0",
+  "lockfileVersion": 1
+}

--- a/package.json
+++ b/package.json
@@ -15,8 +15,7 @@
     "CONTRIBUTORS",
     "LICENSE"
   ],
-  "keywords": [
-  ],
+  "keywords": [],
   "contributors": [
     "Ace Nassri <anassri@google.com>",
     "Alexander Fenster <github@fenster.name>",
@@ -29,10 +28,7 @@
     "Tim Swast <swast@google.com>",
     "greenkeeper[bot] <greenkeeper[bot]@users.noreply.github.com>"
   ],
-  "scripts": {
-  },
-  "dependencies": {
-  },
-  "devDependencies": {
-  }
+  "scripts": {},
+  "dependencies": {},
+  "devDependencies": {}
 }


### PR DESCRIPTION
🔨 update lock files to use the latest gRPC (v1.11.3) and make node10 test use pre-built binary